### PR TITLE
fix package dependency for libreadline-dev

### DIFF
--- a/BuildTools/ubuntu/build64_18.04.sh
+++ b/BuildTools/ubuntu/build64_18.04.sh
@@ -35,7 +35,7 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     sudo apt-get update
     sudo apt-get install libssl-dev 
-    sudo apt-get install libreadline7-dev 
+    sudo apt-get install libreadline-dev 
     sudo apt-get install zlib1g-dev 
     sudo apt-get install libexpat1-dev 
     sudo apt-get install dh-autoreconf 


### PR DESCRIPTION
libreadline7-dev package doesn't exist on Ubuntu 18.04.
Switching to libreadline-dev instead, which is related to version 7 anyway :

$ apt show libreadline-dev | grep Version
Version: 7.0-3